### PR TITLE
ユーザー削除のflashメッセージを追加

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -23,7 +23,8 @@ exports.view = (req, res) => {
       connection.release();
 
       if (!err) {
-        res.render('home', { rows });
+        const removedUser = req.query.removed;
+        res.render('home', { rows, removedUser });
       } else {
         // eslint-disable-next-line no-console
         console.log(err);
@@ -199,7 +200,8 @@ exports.delete = (req, res) => {
       connection.release();
 
       if (!err) {
-        res.redirect('/');
+        const removedUser = encodeURIComponent('User removed');
+        res.redirect(`/?removed=${removedUser}`);
       } else {
         // eslint-disable-next-line no-console
         console.log(err);

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -1,3 +1,10 @@
+{{#if removedUser}}
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        User has been removed successfully.
+        <a href="/" class="btn-close"></a>
+    </div>
+{{/if}}
+
 <div class="row">
     <div class="col-6"><h1>Users</h1></div>
     <div class="col-6 d-flex justify-content-end">


### PR DESCRIPTION
## 実装内容
- ユーザー削除後に表示されるflashメッセージを表示
- flashメッセージのCloseボタンでユーザー一覧

## 確認項目（動作項目）
- [x] ユーザー一覧ページでユーザーを削除すると、flashメッセージが表示される
- [x] ユーザー削除のflashメッセージのCloseボタンをクリックすると`/`へ遷移する 